### PR TITLE
Update to linux-mpu9150 to Allow Raw Sensor Data Retrieval

### DIFF
--- a/libimu.c
+++ b/libimu.c
@@ -33,15 +33,6 @@
 #include "linux_glue.h"
 #include "libimu.h"
 
-
-
-// static void fused_euler_angles(mpudata_t *mpu);
-// static void fused_quaternion(mpudata_t *mpu);
-// static void calibrated_accel(mpudata_t *mpu);
-// static void calibrated_mag(mpudata_t *mpu);
-
-
-
 int i2c_bus;
 int sample_rate;
 int yaw_mix_factor;
@@ -51,10 +42,6 @@ void close_mpu(void)
 {
 	mpu9150_exit();
 }
-
-
-
-
 
 int init_mpu(int sample_rate, int yaw_mix_factor)
 {
@@ -88,6 +75,7 @@ int disableFusion(void) {
 	}
 	return 0;
 }
+
 int read_mpu(float *pitch, float *roll, float *heading)
 {
 	int ret;
@@ -98,41 +86,25 @@ int read_mpu(float *pitch, float *roll, float *heading)
 	*roll = mpu.fusedEuler[1];
 	*heading = mpu.fusedEuler[2];
 	return ret;
-	// fused_euler_angles(&mpu);
-	// fused_quaternions(&mpu);
-	// calibrated_accel(&mpu);
-	// calibrated_mag(&mpu);
 }
 
-// void fused_euler_angles(mpudata_t *mpu)
-// {
-// 	mpu->fusedEuler[VEC3_X] * RAD_TO_DEGREE;
-// 	mpu->fusedEuler[VEC3_Y] * RAD_TO_DEGREE;
-// 	mpu->fusedEuler[VEC3_Z] * RAD_TO_DEGREE;
-// }
-
-
-// void fused_quaternions(mpudata_t *mpu)
-// {
-// 	mpu->fusedQuat[QUAT_W];
-// 	mpu->fusedQuat[QUAT_X];
-// 	mpu->fusedQuat[QUAT_Y];
-// 	mpu->fusedQuat[QUAT_Z];
-// }
-
-// void calibrated_accel(mpudata_t *mpu)
-// {
-// 	mpu->calibratedAccel[VEC3_X];
-// 	mpu->calibratedAccel[VEC3_Y];
-// 	mpu->calibratedAccel[VEC3_Z];
-// }
-
-// void calibrated_mag(mpudata_t *mpu)
-// {
-// 	mpu->calibratedMag[VEC3_X];
-// 	mpu->calibratedMag[VEC3_Y];
-// 	mpu->calibratedMag[VEC3_Z];
-// }
+int read_mpu_raw(float *gx, float *gy, float *gz, float *ax, float *ay, float *az, float *mx, float *my, float *mz)
+{
+	int ret;
+	static mpudata_t mpu;
+	memset(&mpu, 0, sizeof(mpudata_t));
+	ret = mpu9150_read(&mpu);
+	*gx = mpu.rawGyro[0];
+	*gy = mpu.rawGyro[1];
+	*gz = mpu.rawGyro[2];
+	*ax = mpu.rawAccel[0];
+	*ay = mpu.rawAccel[1];
+	*az = mpu.rawAccel[2];
+	*mx = mpu.rawMag[0];
+	*my = mpu.rawMag[1];
+	*mz = mpu.rawMag[2];
+	return ret;
+}
 
 int set_cal(int mag, char *cal_file)
 {

--- a/libimu.h
+++ b/libimu.h
@@ -19,6 +19,7 @@ extern void close_mpu(void);
 //extern int init_mpu(void);
 extern int init_mpu(int sample_rate, int yaw_mix_factor);
 extern int read_mpu(float *pitch, float *roll, float *heading);
+extern int read_mpu_raw(float *gx, float *gy, float *gz, float *ax, float *ay, float *az, float *mx, float *my, float *mz);
 extern int set_cal(int mag, char *cal_file);
 
 extern int enableFusion(void);

--- a/mpu/mpu.go
+++ b/mpu/mpu.go
@@ -62,3 +62,21 @@ func ReadMPU() (pitch, roll, heading float32, err error) {
 	}
 	return
 }
+
+// ReadMPURaw
+func ReadMPURaw() (gx, gy, gz, ax, ay, az, mx, my, mz float32, err error) {
+	i := int(C.read_mpu_raw(
+		(*C.float)(unsafe.Pointer(&gx)),
+		(*C.float)(unsafe.Pointer(&gy)),
+		(*C.float)(unsafe.Pointer(&gz)),
+		(*C.float)(unsafe.Pointer(&ax)),
+		(*C.float)(unsafe.Pointer(&ay)),
+		(*C.float)(unsafe.Pointer(&az)),
+		(*C.float)(unsafe.Pointer(&mx)),
+		(*C.float)(unsafe.Pointer(&my)),
+		(*C.float)(unsafe.Pointer(&mz))))
+	if i == -1 {
+		err = errors.New("error reading MPU")
+	}
+	return
+}

--- a/mpu/mpu.go
+++ b/mpu/mpu.go
@@ -31,6 +31,11 @@ import (
 	"unsafe"
 )
 
+// Raw data struct
+type RawData struct {
+	gx, gy, gz, ax, ay, az, mx, my, mz float32
+}
+
 // Current version.
 var PackageVersion = "v0.2b"
 
@@ -64,17 +69,17 @@ func ReadMPU() (pitch, roll, heading float32, err error) {
 }
 
 // ReadMPURaw
-func ReadMPURaw() (gx, gy, gz, ax, ay, az, mx, my, mz float32, err error) {
+func ReadMPURaw() (d RawData, err error) {
 	i := int(C.read_mpu_raw(
-		(*C.float)(unsafe.Pointer(&gx)),
-		(*C.float)(unsafe.Pointer(&gy)),
-		(*C.float)(unsafe.Pointer(&gz)),
-		(*C.float)(unsafe.Pointer(&ax)),
-		(*C.float)(unsafe.Pointer(&ay)),
-		(*C.float)(unsafe.Pointer(&az)),
-		(*C.float)(unsafe.Pointer(&mx)),
-		(*C.float)(unsafe.Pointer(&my)),
-		(*C.float)(unsafe.Pointer(&mz))))
+		(*C.float)(unsafe.Pointer(&d.gx)),
+		(*C.float)(unsafe.Pointer(&d.gy)),
+		(*C.float)(unsafe.Pointer(&d.gz)),
+		(*C.float)(unsafe.Pointer(&d.ax)),
+		(*C.float)(unsafe.Pointer(&d.ay)),
+		(*C.float)(unsafe.Pointer(&d.az)),
+		(*C.float)(unsafe.Pointer(&d.mx)),
+		(*C.float)(unsafe.Pointer(&d.my)),
+		(*C.float)(unsafe.Pointer(&d.mz))))
 	if i == -1 {
 		err = errors.New("error reading MPU")
 	}


### PR DESCRIPTION
New methods ReadMPURaw in mpu.go and read_mpu_raw in libimu.c/h. These methods get the raw gyro/accel/mag XYZ sensor values without any fusion or external calibration.
